### PR TITLE
Agreement

### DIFF
--- a/colp_build/02_build.sh
+++ b/colp_build/02_build.sh
@@ -8,6 +8,7 @@ psql $BUILD_ENGINE -f sql/create.sql
 psql $BUILD_ENGINE -f sql/map_ipis.sql
 psql $BUILD_ENGINE -f sql/add_geoms.sql
 psql $BUILD_ENGINE -f sql/cat_codes.sql
+psql $BUILD_ENGINE -f sql/agreement.sql
 
 END=$(date +%s);
 echo $((END-START)) | awk '{print int($1/60)" minutes and "int($1%60)" seconds elapsed."}'

--- a/colp_build/sql/agreement.sql
+++ b/colp_build/sql/agreement.sql
@@ -1,0 +1,9 @@
+-- Add agreement types
+UPDATE colp
+SET agreement = CASE
+        WHEN use_code = '1910' THEN 'L'
+        WHEN use_code = '1920' THEN 'S'
+        WHEN use_code = '1930' THEN 'S/L'
+        WHEN use_code = '1900' THEN '*'
+        ELSE NULL
+    END;

--- a/colp_build/sql/agreement.sql
+++ b/colp_build/sql/agreement.sql
@@ -3,7 +3,7 @@ UPDATE colp
 SET agreement = CASE
         WHEN use_code = '1910' THEN 'L'
         WHEN use_code = '1920' THEN 'S'
-        WHEN use_code = '1930' THEN 'S/L'
-        WHEN use_code = '1900' THEN '*'
+        WHEN use_code = '1930' THEN 'M'
+        WHEN use_code = '1900' THEN 'T'
         ELSE NULL
     END;

--- a/colp_build/sql/create.sql
+++ b/colp_build/sql/create.sql
@@ -13,6 +13,7 @@ CREATE TABLE colp(
     ownership text,
     leased text,
     final_commit text,
+    agreement text,
     category_code text,
     expanded_cat_code text,
     mappable text,


### PR DESCRIPTION
Adds flags for agreement type. Current codes are:

- 1910: **'L'** for long-term
- 1920: **'S'** for short-term
- 1930: **'S/L'** for a mix of short- and long-term
- 1900: **'\*'** to indicate that there is an agreement (property is tenanted and in-use), but that length of the agreement is not specified

#17 

@AmandaDoyle I would love input on the codes