### PR TITLE
Overwrite agreements

### DIFF
--- a/colp_build/sql/agreement.sql
+++ b/colp_build/sql/agreement.sql
@@ -1,4 +1,5 @@
 -- Add agreement types
 UPDATE colp
-SET use_code = '1900'
+SET use_code = '1900',
+use_type = 'IN USE-TENANTED'
 WHERE use_code IN ('1910', '1920', '1930');

--- a/colp_build/sql/agreement.sql
+++ b/colp_build/sql/agreement.sql
@@ -1,10 +1,4 @@
 -- Add agreement types
 UPDATE colp
-SET agreement = CASE
-        WHEN use_code = '1910' THEN 'L'
-        WHEN use_code = '1920' THEN 'S'
-        WHEN use_code = '1930' THEN 'M'
-        WHEN use_code = '1900' THEN 'T'
-        ELSE NULL
-    END
-WHERE agreement IS NULL;
+SET use_code = '1900'
+WHERE use_code IN ('1910', '1920', '1930');

--- a/colp_build/sql/map_ipis.sql
+++ b/colp_build/sql/map_ipis.sql
@@ -25,10 +25,12 @@ SELECT
     (CASE WHEN owner IS NULL then 'P' ELSE owner END) as owner,
     owned_leased,
     (CASE WHEN u_f_use_code IS NULL then NULL ELSE 'D' END) as final_commit,
-    (CASE WHEN split_part(u_a_use_code::text, '.', 1) = '1910' THEN 'L'
-        WHEN split_part(u_a_use_code::text, '.', 1) = '1920' THEN 'S'
-        WHEN split_part(u_a_use_code::text, '.', 1) = '1930' THEN 'M'
-        WHEN split_part(u_a_use_code::text, '.', 1) = '1900' THEN 'T' 
+    (CASE WHEN split_part(u_a_use_code::text, '.', 1) = '1910' OR 
+        LPAD(split_part(primary_usecode::text, '.', 1), 4, '0') = '1910' THEN 'L'
+        WHEN split_part(u_a_use_code::text, '.', 1) = '1920'  OR
+        LPAD(split_part(primary_usecode::text, '.', 1), 4, '0') = '1920' THEN 'S'
+        WHEN split_part(u_a_use_code::text, '.', 1) = '1930' OR
+        LPAD(split_part(primary_usecode::text, '.', 1), 4, '0') = '1930' THEN 'M'
         ELSE NULL END) as agreement,
     bbl
 FROM dcas_ipis;


### PR DESCRIPTION
**Updates to how agreements-related use codes are handled**

Going forward, the code 1900 can only appear in `use_code`. The values 1910, 1920, and 1930 should not show up in `use_code`, and are instead only used to map the `agreement` field.

Records with 1910, 1920, 1930 in the primary use code of the current data:
-  The primary use code values 1910, 1920, and 1930 are used to determine the value in `agreement` in case this information isn't already captured in `U_A_USE_CODE`
- Then, `use_code` gets changed to 1900 and the `use_type` gets set as 'IN USE-TENANTED'

Records with 1900 in the  U_A_USE_CODE of current data:
- There is no mapping between this invalid code and the `agreement` field
- Unless 1910, 1920, or 1930 also appears in the primary use code, `agreement` for these records is set to NULL

Ideally, neither of these cases will happen in future input data.