### PR TITLE
47 norm addresses

### DIFF
--- a/colp_build/02_build.sh
+++ b/colp_build/02_build.sh
@@ -7,7 +7,8 @@ docker run --rm\
     -v `pwd`:/home/colp_build\
     -w /home/colp_build\
     -e BUILD_ENGINE=$BUILD_ENGINE\
-    nycplanning/docker-geosupport:latest bash -c "python3 python/geocode.py"
+    nycplanning/docker-geosupport:latest bash -c "python3 python/normalize_addresses.py;
+                                                python3 python/geocode.py"
 
 psql $BUILD_ENGINE -f sql/create_colp.sql
 

--- a/colp_build/python/normalize_addresses.py
+++ b/colp_build/python/normalize_addresses.py
@@ -20,9 +20,8 @@ def get_hnum(house_number_in):
         hnum = re.sub(r"[^0-9a-zA-Z-]+", "", hnum)\
         .replace(' ', '')\
         .strip()\
-        .lstrip("0")\
-        .split("(",maxsplit=1)[0]\
-        .split("/",maxsplit=1)[0]
+        .lstrip('0')\
+        .lstrip('-')
     return hnum
 
 def get_sname(street_name_in): 

--- a/colp_build/python/normalize_addresses.py
+++ b/colp_build/python/normalize_addresses.py
@@ -1,0 +1,63 @@
+from multiprocessing import Pool, cpu_count
+from utils.exporter import exporter
+from geosupport import Geosupport, GeosupportError
+from sqlalchemy import create_engine
+from datetime import date
+import pandas as pd
+import numpy as np
+import json
+import re
+import os 
+
+g = Geosupport()
+engine = create_engine(os.getenv('BUILD_ENGINE'))
+
+def get_hnum(house_number_in):
+    hnum = '' if house_number_in is None else house_number_in.upper()
+    if house_number_in is not None and house_number_in.replace('0','') == '':
+        hnum="0"
+    else:
+        hnum = re.sub(r"[^0-9a-zA-Z-]+", "", hnum)\
+        .replace(' ', '')\
+        .strip()\
+        .lstrip("0")\
+        .split("(",maxsplit=1)[0]\
+        .split("/",maxsplit=1)[0]
+    return hnum
+
+def get_sname(street_name_in): 
+    try:
+        geo = g['N*'](street_name=street_name_in)
+        return geo.get('First Street Name Normalized', '')
+    except:
+        return ''
+
+def normalize(inputs):
+    house_number = inputs.pop('house_number')
+    street_name = inputs.pop('street_name')
+    return {'input_hnum': house_number,
+            'hnum': get_hnum(house_number),
+            'input_sname': street_name, 
+            'sname': get_sname(street_name)}
+
+if __name__ == '__main__':
+
+    df = pd.read_sql('''SELECT DISTINCT house_number, street_name
+                        from dcas_ipis''',
+                    con=engine)
+    print(f'Input data shape: {df.shape}')
+
+    records = df.to_dict('records')
+    
+    print('Address normalization begins here ...')
+    # Multiprocess
+    with Pool(processes=cpu_count()) as pool:
+        it = pool.map(normalize, records, 10000)
+    
+    print('Address normalization finished ...')
+    result = pd.DataFrame(it)
+    print(list(result))
+    print(result.head())
+
+    table_name = f'dcas_ipis_addresses'
+    exporter(result, table_name, con=engine, sep='~', null='')


### PR DESCRIPTION
Street name normalization uses function N.

Function 1L does not have python bindings. This PR includes a script to manually standardize house numbers:
+ Replace numbers that are all 0s with a single 0
+ If not all 0s, strip leading zeros
+ Remove spaces (including changing ' - ' to '-')
+ Remove any non-alphanumeric character that isn't a dash
+ Capitalize letters
+ Remove dashes that don't have anything in front of it

Output is in the table `dcas_ipis_addresses`,  which can get joined on to `colp` as desired.