### PR TITLE
Add exporter workflow

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    if: contains(github.event.head_commit.message, '[export]')
+    env:
+      BUILD_ENGINE: ${{ secrets.BUILD_ENGINE }}
+      AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: install update ...
+      run: |
+        sudo apt update
+        sudo apt install -y postgresql-client-common
+    - name: exporting colp ...
+      working-directory: colp_build
+      run: ./03_export.sh


### PR DESCRIPTION
#76 

Creates export tables from `_colp`, pushes to AWS.

**Possible improvement:** switch to issue-trigger with a comment for export