### PR TITLE
Create air rights output

### DIFF
--- a/colp_build/03_export.sh
+++ b/colp_build/03_export.sh
@@ -10,6 +10,7 @@ mkdir -p output
 
     echo "Exporting COLP"
     CSV_export colp
+    CSV_export unmapped_airrights
     CSV_export colp_unmapped
     CSV_export address_comparison
     echo "[$(date)] $DATE" > version.txt

--- a/colp_build/sql/_export.sql
+++ b/colp_build/sql/_export.sql
@@ -4,6 +4,13 @@ INTO colp
 FROM _colp
 WHERE "XCOORD" IS NOT NULL;
 
+DROP TABLE IF EXISTS unmapped_airrights;
+SELECT *
+INTO unmapped_airrights
+FROM _colp
+WHERE "XCOORD" IS NULL
+AND LEFT("LOT"::text, 1) = '9';
+
 DROP TABLE IF EXISTS colp_unmapped;
 SELECT a.*,
     b.geo_function,


### PR DESCRIPTION
Table of unmapped records, only including air rights lots.
Unlike other unmapped table, this is the same schema as the normal output and doesn't include the diagnostic Geosupport fields.