### PR TITLE
Modify shapefile export for consistency with newer data pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 | File | Description |
 | ---- | ----------- |
 | [output.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/2021-04-01/output/output.zip) | Zipped directory containing all files below |
-| [colp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.zip) | Shapefile version COLP database, only including records with coordinates |
+| [colp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.shp.zip) | Shapefile version COLP database, only including records with coordinates |
 | [colp.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.csv) | CSV version COLP database, only including records with coordinates |
 | [ipis_modified_hnums.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/ipis_modified_hnums.csv) | QAQC table of records with modified house numbers |
 | [ipis_modified_names.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/ipis_modified_names.csv) | QAQC table of records with modified parcel names |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 | File | Description |
 | ---- | ----------- |
 | [output.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/2021-04-01/output/output.zip) | Zipped directory containing all files below |
-| [colp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.shp.zip) | Shapefile version COLP database, only including records with coordinates |
+| [colp.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.shp.zip) | Shapefile version COLP database, only including records with coordinates |
 | [colp.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.csv) | CSV version COLP database, only including records with coordinates |
 | [ipis_modified_hnums.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/ipis_modified_hnums.csv) | QAQC table of records with modified house numbers |
 | [ipis_modified_names.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/ipis_modified_names.csv) | QAQC table of records with modified parcel names |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 ## Outputs
 | File | Description |
 | ---- | ----------- |
+| [output.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/2021-04-01/output/output.zip) | Zipped directory containing all files below |
 | [colp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.zip) | Shapefile version COLP database, only including records with coordinates |
 | [colp.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/colp.csv) | CSV version COLP database, only including records with coordinates |
 | [ipis_modified_hnums.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/latest/output/ipis_modified_hnums.csv) | QAQC table of records with modified house numbers |

--- a/colp_build/03_export.sh
+++ b/colp_build/03_export.sh
@@ -12,6 +12,8 @@ mkdir -p output
 
     echo "Exporting COLP"
     CSV_export colp
+    SHP_export colp POINT
+
     CSV_export ipis_unmapped
     CSV_export ipis_colp_geoerrors
     CSV_export ipis_sname_errors
@@ -25,7 +27,6 @@ mkdir -p output
     CSV_export corrections_not_applied
     echo "[$(date)] $DATE" > version.txt
 
-    SHP_export $BUILD_ENGINE colp POINT colp
 )
 
 zip -r output/output.zip output

--- a/colp_build/config.sh
+++ b/colp_build/config.sh
@@ -34,19 +34,21 @@ function CSV_export {
 }
 
 function SHP_export {
-  urlparse $1
-  mkdir -p $4 &&
-    (
-      cd $4
-      ogr2ogr -progress -f "ESRI Shapefile" $4.shp \
-          PG:"host=$BUILD_HOST user=$BUILD_USER port=$BUILD_PORT dbname=$BUILD_DB password=$BUILD_PWD" \
-          -nlt $3 $2
-        rm -f $4.zip
-        zip -9 $4.zip *
-        ls | grep -v $4.zip | xargs rm
-      )
-  mv $4/$4.zip $4.zip
-  rm -rf $4
+  urlparse $BUILD_ENGINE
+  table=$1
+  geomtype=$2
+  name=${3:-$table}
+  mkdir -p $name &&(
+    cd $name
+    ogr2ogr -progress -f "ESRI Shapefile" $name.shp \
+        PG:"host=$BUILD_HOST user=$BUILD_USER port=$BUILD_PORT dbname=$BUILD_DB password=$BUILD_PWD" \
+        $table -nlt $geomtype
+      rm -f $name.shp.zip
+      zip -9 $name.shp.zip *
+      ls | grep -v $name.shp.zip | xargs rm
+  )
+  mv $name/$name.shp.zip $name.shp.zip
+  rm -rf $name
 }
 
 function Upload {


### PR DESCRIPTION
#118 

Most modifications weren't necessary to fix the bug (it was an issue in the local environment of the last run, along with incorrect file extension), but they keep shapefile uploads consistent with our newer data pipelines for easier debugging going forward.

Also included a link to download a zipped directory of all output tables.