### PR TITLE
fixing export dependencies and functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Install dependencies ...
       run: |
-        sudo apt update
-        sudo apt install -y postgresql-client-common
         curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
         chmod +x mc
         sudo mv ./mc /usr/bin


### PR DESCRIPTION
default to use the gdal docker image to create shapefiles and fgdbs, so that we don't have to spend time and install gdal