### PR TITLE
DCPEDITED Flag Refactoring

### DIFF
--- a/sql/_procedures.sql
+++ b/sql/_procedures.sql
@@ -44,14 +44,14 @@ BEGIN
         RAISE NOTICE 'Applying Correction';
         IF _uid IS NOT NULL THEN
             EXECUTE format($n$
-                UPDATE %1$I SET %2$I = %4$L::%5$s WHERE %1$I.uid = %3$L;
+                UPDATE %1$I SET %2$I = %4$L::%5$s, "DCPEDITED" = 'Y' WHERE %1$I.uid = %3$L;
             $n$, _table, _field, _uid, _new_val, field_type);
             EXECUTE format($n$
                 DELETE FROM modifications_applied WHERE uid = %1$L AND field = %2$L AND old_value = %3$L;
             $n$, _uid, _field, _old_val, _new_val);
         ELSE
             EXECUTE format($n$
-                UPDATE %1$I SET %2$I = %4$L::%5$s WHERE %2$I = %3$L;
+                UPDATE %1$I SET %2$I = %4$L::%5$s, "DCPEDITED" = 'Y'  WHERE %2$I = %3$L;
                 $n$, _table, _field, _old_val, _new_val, field_type);
         END IF;
         EXECUTE format($n$

--- a/sql/_procedures.sql
+++ b/sql/_procedures.sql
@@ -51,7 +51,7 @@ BEGIN
             $n$, _uid, _field, _old_val, _new_val);
         ELSE
             EXECUTE format($n$
-                UPDATE %1$I SET %2$I = %4$L::%5$s, "DCPEDITED" = 'Y'  WHERE %2$I = %3$L;
+                UPDATE %1$I SET %2$I = %4$L::%5$s, "DCPEDITED" = 'Y' WHERE %2$I = %3$L;
                 $n$, _table, _field, _old_val, _new_val, field_type);
         END IF;
         EXECUTE format($n$

--- a/sql/create_colp.sql
+++ b/sql/create_colp.sql
@@ -313,11 +313,11 @@ SELECT DISTINCT
     leased::varchar(2) as "LEASED",
     finalcom::varchar(2) as "FINALCOM",
     agreement::varchar(2) as "AGREEMENT",
-    NULL as "DCPEDITED",
     round(xcoord::numeric)::numeric(10,0) as "XCOORD",
     round(ycoord::numeric)::numeric(10,0) as "YCOORD",
     latitude::numeric(19,7) as "LATITUDE",
     longitude::numeric(19,7) as "LONGITUDE",
+    NULL as "DCPEDITED",
     ST_Transform(geom, 2263) as "GEOM"
 INTO _colp
 FROM categorized;

--- a/sql/create_colp.sql
+++ b/sql/create_colp.sql
@@ -313,6 +313,7 @@ SELECT DISTINCT
     leased::varchar(2) as "LEASED",
     finalcom::varchar(2) as "FINALCOM",
     agreement::varchar(2) as "AGREEMENT",
+    NULL as "DCPEDITED",
     round(xcoord::numeric)::numeric(10,0) as "XCOORD",
     round(ycoord::numeric)::numeric(10,0) as "YCOORD",
     latitude::numeric(19,7) as "LATITUDE",

--- a/sql/export_colp.sql
+++ b/sql/export_colp.sql
@@ -29,9 +29,6 @@ SELECT
     "YCOORD",
     "LATITUDE",
     "LONGITUDE",
-    ---(CASE
-    ---    WHEN uid IN (SELECT DISTINCT uid FROM modifications_applied) THEN 'Y'
-    ---END)::varchar(1) as "DCPEDITED",
     "DCPEDITED",
     "GEOM"
 INTO colp

--- a/sql/export_colp.sql
+++ b/sql/export_colp.sql
@@ -29,9 +29,10 @@ SELECT
     "YCOORD",
     "LATITUDE",
     "LONGITUDE",
-    (CASE
-        WHEN uid IN (SELECT DISTINCT uid FROM modifications_applied) THEN 'Y'
-    END)::varchar(1) as "DCPEDITED",
+    ---(CASE
+    ---    WHEN uid IN (SELECT DISTINCT uid FROM modifications_applied) THEN 'Y'
+    ---END)::varchar(1) as "DCPEDITED",
+    "DCPEDITED",
     "GEOM"
 INTO colp
 FROM _colp


### PR DESCRIPTION
Address #200 

## Issue Description
Since the changes made to the `modification_applied` table, the exporting step was no longer able to fetch the uid from the table to update the `DCPEDITED` column to reflect the records being updated. 

## Solution
Following @abrieff suggestion, a column is created in the initialization step and then later set to `'Y'` in the `_procedure.sql` as the modifications are being applied to the records. This should result in no changes in any of the modification table and only impact the `_colp` and final output table. 