### PR TITLE
update postgis image to 12-3.0-alpine to match other repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       github.event_name == 'workflow_dispatch' 
     services:
       db:
-        image: postgis/postgis:11-3.0-alpine
+        image: postgis/postgis:12-3.0-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
Address issue #207. One reviewer ⭐ 

I think this should be pretty straightforward - historically, we have had some issues with having different versions of postgis so trying to update/standardize across all of our repos. Followed the work @SashaWeinstein did to update DevDB postgis https://github.com/NYCPlanning/db-developments/pull/535