### PR TITLE
Run build on workflow dispatch or closed PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
 name: Build
 on: 
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [closed]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
-    if: >- 
-      contains(github.event.head_commit.message, '[build]') ||
-      github.event_name == 'workflow_dispatch' 
     services:
       db:
         image: postgis/postgis:12-3.0-alpine


### PR DESCRIPTION
Simple PR, just one reviewer 🚪 
Addresses issue #209 
Previously the build action would run on push but the actual `build` job that ran the pipeline would only run on pushes that had `[build]` in the commit message. I don't like this way of triggering a build, we don't build enough to save any time by committing instead of hitting the green button on the website. Additionally this created all these do-nothing runs like https://github.com/NYCPlanning/db-colp/actions/runs/2840537868 that clogged up the list of runs 
