### PR TITLE
Geospatial Check

### DIFF
--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -5,5 +5,6 @@ import_public dcp_pluto &
 import_public dcp_colp &
 import_public dcas_ipis &
 import_public dof_air_rights_lots &
+import_public dcp_boroboundaries_wi &
 wait 
 echo "dataloading complete"

--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 source bash/config.sh
 
-# psql $BUILD_ENGINE -f sql/load_modifications.sql  
+psql $BUILD_ENGINE -f sql/load_modifications.sql  
 
-# psql $BUILD_ENGINE -f sql/geo_inputs.sql
+psql $BUILD_ENGINE -f sql/geo_inputs.sql
 
-# docker run --rm\
-#     --network host\
-#     -v `pwd`:/home/colp_build/\
-#     -w /home/colp_build\
-#     -u $(id -u ${USER}):$(id -g ${USER}) \
-#     -e BUILD_ENGINE=$BUILD_ENGINE\
-#     nycplanning/docker-geosupport:latest bash -c "python3 -m python.geo_qaqc;
-#                                                 python3 -m python.geocode"
+docker run --rm\
+    --network host\
+    -v `pwd`:/home/colp_build/\
+    -w /home/colp_build\
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    -e BUILD_ENGINE=$BUILD_ENGINE\
+    nycplanning/docker-geosupport:latest bash -c "python3 -m python.geo_qaqc;
+                                                python3 -m python.geocode"
 
-# psql $BUILD_ENGINE -f sql/_procedures.sql
-# psql $BUILD_ENGINE -f sql/clean_parcelname.sql
-# psql $BUILD_ENGINE -f sql/create_colp.sql
-# psql $BUILD_ENGINE -f sql/geo_qaqc.sql
+psql $BUILD_ENGINE -f sql/_procedures.sql
+psql $BUILD_ENGINE -f sql/clean_parcelname.sql
+psql $BUILD_ENGINE -f sql/create_colp.sql
+psql $BUILD_ENGINE -f sql/geo_qaqc.sql
 
-# psql $BUILD_ENGINE -1 -c "CALL apply_correction('_colp', 'modifications');"
+psql $BUILD_ENGINE -1 -c "CALL apply_correction('_colp', 'modifications');"
 
 psql $BUILD_ENGINE -f sql/qc_geospatial_check.sql 
 

--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
 source bash/config.sh
 
-psql $BUILD_ENGINE -f sql/load_modifications.sql  
+# psql $BUILD_ENGINE -f sql/load_modifications.sql  
 
-psql $BUILD_ENGINE -f sql/geo_inputs.sql
+# psql $BUILD_ENGINE -f sql/geo_inputs.sql
 
-docker run --rm\
-    --network host\
-    -v `pwd`:/home/colp_build/\
-    -w /home/colp_build\
-    -u $(id -u ${USER}):$(id -g ${USER}) \
-    -e BUILD_ENGINE=$BUILD_ENGINE\
-    nycplanning/docker-geosupport:latest bash -c "python3 -m python.geo_qaqc;
-                                                python3 -m python.geocode"
+# docker run --rm\
+#     --network host\
+#     -v `pwd`:/home/colp_build/\
+#     -w /home/colp_build\
+#     -u $(id -u ${USER}):$(id -g ${USER}) \
+#     -e BUILD_ENGINE=$BUILD_ENGINE\
+#     nycplanning/docker-geosupport:latest bash -c "python3 -m python.geo_qaqc;
+#                                                 python3 -m python.geocode"
 
-psql $BUILD_ENGINE -f sql/_procedures.sql
-psql $BUILD_ENGINE -f sql/clean_parcelname.sql
-psql $BUILD_ENGINE -f sql/create_colp.sql
-psql $BUILD_ENGINE -f sql/geo_qaqc.sql
+# psql $BUILD_ENGINE -f sql/_procedures.sql
+# psql $BUILD_ENGINE -f sql/clean_parcelname.sql
+# psql $BUILD_ENGINE -f sql/create_colp.sql
+# psql $BUILD_ENGINE -f sql/geo_qaqc.sql
 
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('_colp', 'modifications');"
+# psql $BUILD_ENGINE -1 -c "CALL apply_correction('_colp', 'modifications');"
+
+psql $BUILD_ENGINE -f sql/qc_geospatial_check.sql 
 
 echo "Generate output tables"
 psql $BUILD_ENGINE -f sql/export_colp.sql

--- a/sql/qc_geospatial_check.sql
+++ b/sql/qc_geospatial_check.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS geospatial_check;
+CREATE TABLE IF NOT EXISTS geospatial_check(
+    result character varying
+);
+
+INSERT INTO geospatial_check (
+select  jsonb_agg(t) as result
+from (
+    select jsonb_agg(json_build_object('uid', tmp.uid, 'hnum', tmp.HNUM, 'sname', tmp.sname, 
+    'adress', tmp.address, 'parcelname', tmp.PARCELNAME, 'agency', tmp.AGENCY, 
+    'latitude', tmp.latitude,'longitude', tmp.longitude, 'v', tmp.v)) as values, 
+                              'projects_not_within_NYC' as field
+	from (SELECT a.uid, a.HNUM, a.sname, a.address, a.PARCELNAME, a.AGENCY, a.latitude, a.longitude, a.v
+          FROM dcp_colp a, 
+               (SELECT ST_Union(wkb_geometry) geom
+               FROM dcp_boroboundaries_wi) combined 
+          WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.wkb_geometry), combined.geom)) tmp
+    )t
+);

--- a/sql/qc_geospatial_check.sql
+++ b/sql/qc_geospatial_check.sql
@@ -17,3 +17,18 @@ from (
           WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.wkb_geometry), combined.geom)) tmp
     )t
 );
+
+INSERT INTO geospatial_check (
+select  jsonb_agg(t) as result
+from (
+    select jsonb_agg(json_build_object('uid', tmp.uid, 'borough', tmp.borough, 'cd', tmp.cd,  
+    'bbl', tmp.bbl, 'v', tmp.v)) as values, 
+                              'projects_inconsistent_geographies' as field
+	from (
+        select uid, borough, cd, bbl, v
+        FROM dcp_colp
+        WHERE borough <> LEFT(cd::TEXT, 1)
+        OR borough <> LEFT(bbl::TEXT, 1)
+    ) tmp
+    )t
+);


### PR DESCRIPTION
#211  🌻 one reviewer

I fashioned the work after what Jingyi did for cpdb geospatial check. At least for the first projects_not_within_NYC, it should look similar if not identical. 

## projects_inconsistent_geographies
this is a response to [Amanda's comment](https://github.com/NYCPlanning/data-engineering-qaqc/issues/164#issuecomment-1211446874) about a kind of geography checks across multiple data products. It is really to see whether the geocoded results lined up with the other geography attributes in the data products. In this case, the borocode is checked against the CD and also BBL. In this case, the cd in colp comes from pluto with a bbl join. So it is likely the error can be traced back to pluto. 

## json_agg
I hope my understanding of how to json_agg is correct here that each check should be a row and object to be unpacked. If that's not the case, happy to make change accordingly. 