### PR TITLE
Qaqc geo python call in build

### DIFF
--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -11,7 +11,8 @@ docker run --rm\
     -w /home/colp_build\
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -e BUILD_ENGINE=$BUILD_ENGINE\
-    nycplanning/docker-geosupport:latest bash -c "python3 -m python.geocode"
+    nycplanning/docker-geosupport:latest bash -c "python3 -m python.geocode;
+                                                  python3 -m python.geo_qaqc"
 
 psql $BUILD_ENGINE -f sql/_procedures.sql
 psql $BUILD_ENGINE -f sql/clean_parcelname.sql

--- a/bash/03_qaqc.sh
+++ b/bash/03_qaqc.sh
@@ -2,13 +2,6 @@
 source bash/config.sh
 
 echo "Running QAQC"
-docker run --rm\
-    --network host\
-    -v `pwd`:/home/colp_build/\
-    -w /home/colp_build\
-    -u $(id -u ${USER}):$(id -g ${USER}) \
-    -e BUILD_ENGINE=$BUILD_ENGINE\
-    nycplanning/docker-geosupport:latest bash -c "python3 -m python.geo_qaqc"
 
 psql $BUILD_ENGINE -f sql/geo_qaqc.sql
 psql $BUILD_ENGINE -f sql/export_qaqc.sql


### PR DESCRIPTION
Easy PR to undo earlier refactor, one reviewer needed 😞 
Moving the call to `python/geo_qaqc.py` to the qaqc bash script was a breaking change, we should have caught it during testing