### PR TITLE
add export step for the geospatial check file

### DIFF
--- a/bash/04_export.sh
+++ b/bash/04_export.sh
@@ -21,6 +21,7 @@ mkdir -p output && (
     CSV_export usetype_changes
     CSV_export modifications_applied
     CSV_export modifications_not_applied
+    CSV_export geospatial_check
     echo "[$(date)] $DATE" > version.txt
 
 )


### PR DESCRIPTION
It seems like we didn't include the export step for the geospatial check table in the previous pr. So address this issue in this pr. 